### PR TITLE
feat: Add map type attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
       </button>
       <select id="map-select"></select>
       <input type="text" id="map-name" placeholder="Map name">
+      <select id="map-type-select"></select>
     </span>
 
     <span class="controls">

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
+export const mapTypes = ["public", "private"];
+
 // Color mapping for characters
 export const tileTypes = {
   'Ž': '#baf455',

--- a/src/file.js
+++ b/src/file.js
@@ -1,11 +1,14 @@
 import { maps, setCurrentMapIndex, renderCurrentMap, updateMapSelect } from './main';
-import { TransferPoint, LivingPoint } from './constants';
+import { TransferPoint, LivingPoint, mapTypes } from './constants';
 
 // Download map
 export function downloadMap() {
   let content = '';
   maps.forEach(map => {
     content += `[map=${map.name}]\n`;
+    if (map.type) {
+      content += `type=${map.type}\n`;
+    }
     content += '[tiles]\n';
     content += map.grid.map(row => row.join('')).join('\n');
     content += '\n[points]\n';
@@ -43,7 +46,13 @@ export function uploadMap(event) {
     mapSections.forEach(section => {
       const nameEndIndex = section.indexOf(']');
       const name = section.substring(0, nameEndIndex);
-      const restOfSection = section.substring(nameEndIndex + 1);
+      const restOfSection = section.substring(nameEndIndex + 1).trim();
+
+      let type = mapTypes[0];
+      const typeEndIndex = restOfSection.indexOf('\n');
+      if (typeEndIndex !== -1 && restOfSection.substring(0, typeEndIndex).startsWith('type=')) {
+        type = restOfSection.substring(5, typeEndIndex);
+      }
 
       const tilesIndex = restOfSection.indexOf('[tiles]');
       const pointsIndex = restOfSection.indexOf('[points]');
@@ -91,7 +100,7 @@ export function uploadMap(event) {
           }
         });
       }
-      newMaps.push({ name, grid, points });
+      newMaps.push({ name, grid, points, type });
     });
 
     if (newMaps.length > 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,11 @@
-import { tileTypes, TransferPoint, LivingPoint, defaultTileType } from './constants';
+import { mapTypes, tileTypes, TransferPoint, LivingPoint, defaultTileType } from './constants';
 import { downloadMap, uploadMap } from './file';
 
 // Toolbar-1
 const newMapBtn = document.getElementById('new-map');
 const mapSelect = document.getElementById('map-select');
 const mapNameInput = document.getElementById('map-name');
+const mapTypeSelect = document.getElementById('map-type-select');
 
 const widthInput = document.getElementById('width');
 const heightInput = document.getElementById('height');
@@ -44,6 +45,7 @@ let selectedPoint = null;
 // Initialize
 function init() {
   createNewMap();
+  updateMapTypeSelect();
 }
 
 export function setCurrentMapIndex(index) {
@@ -51,9 +53,10 @@ export function setCurrentMapIndex(index) {
 }
 
 // Create a new map
-function createNewMap(name = 'unnamed', grid, points) {
+function createNewMap(name = 'unnamed', grid, points, type) {
   const newMap = {
     name: name,
+    type: type || mapTypes[0],
     grid: grid || Array(10).fill(defaultTileType).map(() => Array(10).fill(defaultTileType)),
     points: points || []
   };
@@ -61,6 +64,7 @@ function createNewMap(name = 'unnamed', grid, points) {
   currentMapIndex = maps.length - 1;
   renderCurrentMap();
   updateMapSelect();
+  updateMapTypeSelect();
 }
 
 export function renderCurrentMap() {
@@ -96,6 +100,24 @@ export function renderCurrentMap() {
   widthInput.value = currentWidth;
   heightInput.value = currentHeight;
   mapNameInput.value = map.name;
+  mapTypeSelect.value = map.type;
+}
+
+function updateMapTypeSelect() {
+  mapTypeSelect.innerHTML = '';
+  mapTypes.forEach(type => {
+    const option = document.createElement('option');
+    option.value = type;
+    option.textContent = type;
+    mapTypeSelect.appendChild(option);
+  });
+}
+
+function updateMapType() {
+  const newType = mapTypeSelect.value;
+  if (newType && maps[currentMapIndex]) {
+    maps[currentMapIndex].type = newType;
+  }
 }
 
 export function updateMapSelect() {
@@ -179,6 +201,7 @@ mapSelect.addEventListener('change', (e) => {
 });
 
 mapNameInput.addEventListener('change', updateMapName);
+mapTypeSelect.addEventListener('change', updateMapType);
 
 generateBtn.addEventListener('click', () => {
   const map = maps[currentMapIndex];


### PR DESCRIPTION
This change introduces a new `type` attribute for maps, which can be set to "public" or "private" from a dropdown in the UI.

The map file format is updated to save and load this new attribute. Older map files without the `type` field will default to "public". The available map types are now defined in `src/constants.js` for easy extension.